### PR TITLE
make app accessible only after signup/login

### DIFF
--- a/app/(auth)/_layout.jsx
+++ b/app/(auth)/_layout.jsx
@@ -1,0 +1,18 @@
+import { useRouter, Slot } from 'expo-router';
+import { useContext, useEffect } from 'react';
+import { AuthContext } from '../context/AuthContext';
+
+export default function AuthLayout() {
+  const { user } = useContext(AuthContext);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.replace('/menus');
+    }
+  }, [user]);
+
+  if (user) return null;
+
+  return <Slot />;
+}

--- a/app/(auth)/login.jsx
+++ b/app/(auth)/login.jsx
@@ -8,6 +8,8 @@ import config from '../config';
 
 export default function Tab() {
   const url = config.BASE_URL;
+  const router = useRouter();
+  const { setUser } = useContext(AuthContext);
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -19,8 +21,12 @@ export default function Tab() {
     } else {
       try {
         const response = await axios.post(`${url}/api/users/login`, { username: username, password: password });
-        console.log("Login Success");
-        console.log(response.data);
+        console.log("Login successful");
+        console.log(response.data._id);
+        const { userId, token } = response.data
+        await SecureStore.setItemAsync('user', JSON.stringify({ userId, token }));
+        setUser({ userId, token });
+        router.replace('/menus');
         return true;
       }
       catch (error) {
@@ -51,7 +57,9 @@ export default function Tab() {
         placeholder="Enter your password"
       />
 
-      <Pressable onPress={handleSubmit}><Text>Log In</Text></Pressable>
+      <Pressable onPress={async () =>  await handleSubmit()}>
+        <Text>Log In</Text>
+      </Pressable>
     </View>
   );
 }

--- a/app/(auth)/signup.jsx
+++ b/app/(auth)/signup.jsx
@@ -63,7 +63,6 @@ export default function Tab() {
     }
   };
 
-
   return (
     <View style={styles.container}>
       <Text>Signup Page</Text>

--- a/app/(tabs)/_layout.jsx
+++ b/app/(tabs)/_layout.jsx
@@ -1,8 +1,21 @@
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faUtensils, faHeart, faComment, faUser } from '@fortawesome/free-solid-svg-icons';
-import { Tabs } from 'expo-router';
+import { useRouter, Tabs } from 'expo-router';
+import { useContext, useEffect } from 'react';
+import { AuthContext } from '../context/AuthContext';
 
 export default function TabLayout() {
+  const { user } = useContext(AuthContext);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) {
+      router.replace('/signup');
+    }
+  }, [user]);
+
+  if (!user) return null;
+
   return (
     <Tabs screenOptions={{ tabBarActiveTintColor: 'blue' }}>
       <Tabs.Screen
@@ -33,26 +46,6 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <FontAwesomeIcon size={28} icon={faUser} color={color} />,
         }}
       />
-      <Tabs.Screen
-        name="signup"
-        options={{
-          title: 'Signup',
-          tabBarIcon: ({ color }) => <FontAwesomeIcon size={28} icon={faUser} color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="login"
-        options={{
-          href: null,
-        }}
-      />
-      {/* USE THIS TO HIDE THE SIGNUP TAB */}
-      {/* <Tabs.Screen
-        name="signup"
-        options={{
-          href: null,
-        }}
-      /> */}
     </Tabs>
   );
 }

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -1,12 +1,62 @@
-import { Stack } from 'expo-router';
-import { AuthProvider } from './context/AuthContext'
+// import { Stack } from 'expo-router';
+// import { AuthProvider } from './context/AuthContext'
+// import AsyncStorage from '@react-native-async-storage/async-storage';
+// import React, { useState, useEffect } from "react";
+// import { ActivityIndicator } from 'react-native';
 
-export default function Layout() {
+// const LOGIN_KEY = "isloggedin";
+
+// export default function Layout() {
+//   const [isLoggedIn, setIsLoggedIn] = useState(false);
+//   const [isLoading, setIsLoading] = useState(true);
+  
+//   useEffect(() => {
+//     const checkLoginStatus = async () => {
+//       try {
+//         console.log("Checking AsyncStorage for login status...");
+//         const loggedIn = await AsyncStorage.getItem(LOGIN_KEY);
+//         console.log("AsyncStorage status:", loggedIn);
+        
+//         if (loggedIn === 'true') {
+//           console.log("User is logged in, showing main app");
+//           setIsLoggedIn(true);
+//         } else {
+//           console.log("User is not logged in, showing intro");
+//           setIsLoggedIn(false);
+//         }
+//       } catch (error) {
+//         console.log('Error checking login status:', error);
+//         setIsLoggedIn(false);
+//       } finally {
+//         setIsLoading(false);
+//       }
+//     };
+//     checkLoginStatus();
+//   })
+
+//   if (isLoading) return <ActivityIndicator />;
+
+//   return isLoggedIn? (
+//     <AuthProvider>
+//       <Stack>
+//         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+//       </Stack>
+//     </AuthProvider>
+//   ) : (
+//     <AuthProvider>
+//       <Stack>
+//         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+//       </Stack>
+//     </AuthProvider>
+//   );
+// }
+import { Slot } from 'expo-router';
+import { AuthProvider } from './context/AuthContext';
+
+export default function RootLayout() {
   return (
     <AuthProvider>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      </Stack>
+      <Slot />
     </AuthProvider>
   );
 }

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return <Redirect href="/(tabs)/menus" />;
+  return <Redirect href="/(auth)/signup" />;
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-image": "~2.1.7",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.0.6",
+    "expo-secure-store": "~14.2.3",
     "expo-splash-screen": "~0.30.8",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.4",
@@ -40,8 +41,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-secure-store": "~14.2.3"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
- use context; created AuthContext which references the SecureStore to check if user exists (based on login)
- if user isn't logged in yet, then can only access signup/login page
- once user is logged in, can see the actual app